### PR TITLE
fix: 닉네임 변경 시 post, comment 테이블의 닉네임도 같이 업데이트

### DIFF
--- a/src/components/MyPage/MyPosts.jsx
+++ b/src/components/MyPage/MyPosts.jsx
@@ -10,6 +10,7 @@ const Container = styled.div`
   display: grid;
   gap: 30px;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  text-align: center;
 `;
 
 const Card = styled.div`
@@ -47,6 +48,10 @@ const EditBtn = styled.button`
   &:hover {
     background-color: #d2d2d2;
   }
+`;
+
+const ContentsNone = styled.p`
+  grid-column: 1 / -1;
 `;
 
 const MyPosts = () => {
@@ -97,7 +102,7 @@ const MyPosts = () => {
           </Card>
         ))
       ) : (
-        <p>등록된 게시물이 없습니다.</p>
+        <ContentsNone>등록된 게시물이 없습니다.</ContentsNone>
       )}
     </Container>
   );

--- a/src/components/MyPage/Nickname.jsx
+++ b/src/components/MyPage/Nickname.jsx
@@ -48,9 +48,13 @@ const Nickname = () => {
       return;
     }
 
-    const { data } = await supabase.auth.updateUser({
+    await supabase.auth.updateUser({
       data: { nickname: updateNickname }
     });
+
+    await supabase.from("posts").update({ nickname: updateNickname }).eq("user_id", userInfo.id);
+    await supabase.from("comments").update({ nickname: updateNickname }).eq("user_id", userInfo.id);
+
     setUpdateNickname("");
     setEdited(false);
   };


### PR DESCRIPTION
## ✅ 작업 사항

- 닉네임 변경 시 post, comment 테이블의 닉네임도 같이 업데이트
-

## 📌 변경 사항

-
-

## 🧑‍💻 기타

-
-
